### PR TITLE
Make a post processing stencil to flash damage feedback on hit

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -59,6 +59,7 @@ r.Shadow.Virtual.Enable=1
 r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange=True
 r.DefaultFeature.LocalExposure.HighlightContrastScale=0.8
 r.DefaultFeature.LocalExposure.ShadowContrastScale=0.8
+r.CustomDepth=3
 
 [/Script/WorldPartitionEditor.WorldPartitionEditorSettings]
 CommandletClass=Class'/Script/UnrealEd.WorldPartitionConvertCommandlet'

--- a/Content/Input/Controllers/PlayerController.uasset
+++ b/Content/Input/Controllers/PlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:413eece224099a15b1f159353fae565ccc89d9108ffc26d7334d18dcf3ec9e1b
-size 106715
+oid sha256:d192052c1410020ff5c50f7d0ea74f3442d8875b00415a39eb78f79ec4fb57ee
+size 105794

--- a/Content/Pawns/CommonGridPawnBP.uasset
+++ b/Content/Pawns/CommonGridPawnBP.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d64ec653c8cddbb0b871aac0ed9155cae4eee6d1f647e6ea4480a370183ca29e
-size 103053
+oid sha256:3538293e5625a4b00fe9166e4c788df4cfb413bba879cecc649d1e055b910d44
+size 115355

--- a/Content/Pawns/PPM_FlashingDamageStencil.uasset
+++ b/Content/Pawns/PPM_FlashingDamageStencil.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78458ccad7650362a902b86e6c0d1fd05b077dc219658bd9ed83ef09145c5120
+size 17106

--- a/Content/Pawns/Player/GridPawnBP.uasset
+++ b/Content/Pawns/Player/GridPawnBP.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f964a2248ba44a9227558b604bb6e58e6d2cafa444d478bc224fcc50c7b69d1
-size 2381

--- a/Content/Pawns/Player/PlayerPawn.uasset
+++ b/Content/Pawns/Player/PlayerPawn.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c91ec3895cb8a9202f01e9a9277dfe5b9a3585fdc5f06632b2af5692a86244e3
-size 319348
+oid sha256:f579b97a8722ffa579ee1712ec8e2a3c256022ec6f9a99e045768c64dde06c88
+size 320037

--- a/Content/__ExternalActors__/Levels/Battle/5/MZ/EDP3YOKRJ352TR68INY6TA.uasset
+++ b/Content/__ExternalActors__/Levels/Battle/5/MZ/EDP3YOKRJ352TR68INY6TA.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:428c4bdc7d6b9f70019fa04e03ca15712153e3174c31e481720647f5c0d00617
+oid sha256:285b9bd2e7cd0ac2af4146f3a6ce071a7bcf78f950faa95958b117c12c5a449f
 size 4696

--- a/Content/__ExternalActors__/Levels/Battle/6/8G/I3JE6ACJZLMUZIKAM6NWBN.uasset
+++ b/Content/__ExternalActors__/Levels/Battle/6/8G/I3JE6ACJZLMUZIKAM6NWBN.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d92f013105b4ca161129861d83f31c78d1e06ae7d6342c1e1ce51a313a66688a
+size 9551

--- a/Content/__ExternalActors__/Levels/Battle/8/HV/2KOSOP0K1MGD0Q5BLAEJWP.uasset
+++ b/Content/__ExternalActors__/Levels/Battle/8/HV/2KOSOP0K1MGD0Q5BLAEJWP.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1303505663de125008df5ad9c45456c0c9630771638a8f0f65801c9670a1ad1c
-size 4668
+oid sha256:68511c10d5b34fbec9832cca18af2615d9616ec9e4d362414e96f7ed6864ff8f
+size 4502


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Add a post processing to the volume, big enough to cover the battlefield (the camera needs to be inside de volume for the post processing effect be applied but we shouldnt be moving the camera too much in the world, its mostly fixed position)

When a GridPawn is dealt any damage, apply the custom post process material created for 0.1s so the actors flashes and the player see damage feedback.

## Fixes # (issue)

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] My changes generate no new warnings -- theres somethin about material emitting more light? need to research this a bit
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
