### PR TITLE
Bugfix/fix memory leaks

### DIFF
--- a/Content/__ExternalActors__/Levels/Battle/3/TD/KI953ES0KWEU9KI7O7M6JR.uasset
+++ b/Content/__ExternalActors__/Levels/Battle/3/TD/KI953ES0KWEU9KI7O7M6JR.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9784b4d290a6081ccc9bbe3d3931ccb67551d69eda649e2ed65e1c4f278ef2e7
-size 4694

--- a/Source/AmebamanBattleNetjob/BattleManager.cpp
+++ b/Source/AmebamanBattleNetjob/BattleManager.cpp
@@ -81,8 +81,8 @@ void ABattleManager::ExecuteAttackOnGrid(AGrid* grid, FIntVector target, int dam
 	FTileData gridData;
 	if (grid->GetPawnInfo(target, gridData)){
 		AGridPawn* gridPawnInLocation = gridData.Pawn;
-		if (gridPawnInLocation != nullptr){
-			gridPawnInLocation -> DamagePawn(damage);
+		if (IsValid(gridPawnInLocation)){
+			gridPawnInLocation->DamagePawn(damage);
 		}
 	}
 }

--- a/Source/AmebamanBattleNetjob/Grid.cpp
+++ b/Source/AmebamanBattleNetjob/Grid.cpp
@@ -68,7 +68,10 @@ void AGrid::GenerateGrid(int width, int depth, int height) {
 }
 
 void AGrid::PlacePawnInGrid(AGridPawn *pawn, FIntVector gridPosition){
-	ensureMsgf(IsValidPosition(gridPosition), TEXT("Trying to place pawn in invalid grid position"));
+	if(!IsValidPosition(gridPosition)){
+		UE_LOG(LogTemp, Warning, TEXT("[%s.PlacePawnInGrid()] Trying to place pawn in invalid grid position, placing at [0, 0, 0]"), *GetName());
+		gridPosition = FIntVector {0, 0, 0};
+	}
 	
 	int gridIndex = FIntVectorToGridArrayIndex(gridPosition);
 	GridData[gridIndex]->Pawn = pawn;
@@ -185,6 +188,8 @@ bool AGrid::GetPawnInfo(FIntVector gridLocation, FTileData& result) {
 }
 
 int32 AGrid::RemovePawnFromGrid(AGridPawn* pawn){
+	if(!IsValid(pawn)) return;
+	
 	FTileData tileData;
 	if(GetPawnInfo(pawn, tileData)){
 		GridPawnMap.Remove(pawn->GetName());

--- a/Source/AmebamanBattleNetjob/Grid.cpp
+++ b/Source/AmebamanBattleNetjob/Grid.cpp
@@ -116,7 +116,7 @@ inline bool AGrid::IsGridLocationEmpty(FIntVector location){
 }
 
 
-bool AGrid::CalculateTargetGridPosition(AGridPawn *pawn, FIntVector direction, int32 scale, FIntVector &result){
+bool AGrid::CalculateTargetGridPosition(const AGridPawn *pawn, FIntVector direction, int32 scale, FIntVector &result){
 	FIntVector currentLocation = GridArrayIndexToFIntVector(GridPawnMap[pawn->GetName()].Id);
 	return CalculateTargetGridPosition(currentLocation, direction, scale, result);
 }
@@ -162,7 +162,7 @@ inline FIntVector AGrid::GridArrayIndexToFIntVector(int idx) {
     return FIntVector(x, y, z);
 }
 
-inline bool AGrid::IsPawnInGrid(AGridPawn *pawn){
+inline bool AGrid::IsPawnInGrid(const AGridPawn *pawn){
 	return GridPawnMap.Find(pawn->GetName()) != nullptr;
 }
 
@@ -186,7 +186,7 @@ bool AGrid::GetPawnInfo(FIntVector gridLocation, FTileData& result) {
 	return true;
 }
 
-int32 AGrid::RemovePawnFromGrid(AGridPawn* pawn){
+int32 AGrid::RemovePawnFromGrid(AGridPawn *pawn){
 	if(!IsValid(pawn)) {
 		UE_LOG(LogTemp, Warning, TEXT("[%s.RemovePawnFromGrid()] Trying to remove invalid pawn from grid, ignoring (did you call Destroy on this pawn before this?)"), *GetName());
 		return GridPawnMap.Num();

--- a/Source/AmebamanBattleNetjob/Grid.h
+++ b/Source/AmebamanBattleNetjob/Grid.h
@@ -89,8 +89,6 @@ protected:
 	inline bool IsGridLocationEmpty(FIntVector location);
 
 private:
-	//UPROPERTY() --> WE NEED THIS TO WORK TO NOT HAVE MEMORY LEAK. HOWEVER IT WILL NOT WORK WITH THE POINTER AS IT IS TODAY
-	TArray<FTileData *> GridData;
-	//UPROPERTY() --> WE NEED THIS TO WORK TO NOT HAVE MEMORY LEAK. HOWEVER IT WILL NOT WORK WITH THE POINTER AS IT IS TODAY
-	TMap<FString, FTileData *> GridPawnMap;
+	TArray<FTileData> GridData;
+	TMap<FString, FTileData> GridPawnMap;
 };

--- a/Source/AmebamanBattleNetjob/Grid.h
+++ b/Source/AmebamanBattleNetjob/Grid.h
@@ -40,7 +40,7 @@ public:
 	UFUNCTION(BlueprintCallable)
 	inline FIntVector WorldToGridLocation(FVector location);
 	UFUNCTION(BlueprintCallable)
-	bool CalculateTargetGridPosition(AGridPawn *pawn, FIntVector direction, int32 scale, FIntVector &result);
+	bool CalculateTargetGridPosition(const AGridPawn *pawn, FIntVector direction, int32 scale, FIntVector &result);
 	bool CalculateTargetGridPosition(FIntVector currentLocation, FIntVector direction, int32 scale, FIntVector &result);
 	UFUNCTION(BlueprintCallable)
 	void MovePawnInGrid(AGridPawn *pawn, FIntVector newLocation);
@@ -57,7 +57,7 @@ public:
 	inline FVector GridToWorldLocation(int x, int y, int z);
 
 	UFUNCTION()
-	inline bool IsPawnInGrid(AGridPawn *pawn);
+	inline bool IsPawnInGrid(const AGridPawn *pawn);
 	UFUNCTION()
 	bool GetPawnInfo(AGridPawn *pawn, FTileData& result);
 	bool GetPawnInfo(FIntVector gridLocation, FTileData& result);
@@ -69,7 +69,7 @@ public:
 	inline int FIntVectorToGridArrayIndex(int x, int y, int z);
 	inline int FIntVectorToGridArrayIndex(FIntVector index3D);
 	inline FIntVector GridArrayIndexToFIntVector(int idx);
-	int32 RemovePawnFromGrid(AGridPawn* pawn);
+	int32 RemovePawnFromGrid(AGridPawn *pawn);
 
 protected:
 	// Called when the game starts or when spawned


### PR DESCRIPTION
# Description
*Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.*

There was an inconsistency with the way `FTileData` was being used and allocated. When generating a grid, it was being alocatted with new but there was no call to the object destructors. 
Secondly, `GridData` array and `GridPawnMap` table were both storing pointers to the `FTileData` struct but those are already memory-managed allocated containers, we should use just the value type here.

## Consequences
*List all consequences, both negative and positive, this changes makes and other features that could be affected by these changes.*

No more memory leaks for the grid's data array and table and more consistency when using pointers and reference types.
For reference: we should use pointers when passing an argument that should not be modified and that pointer should be declared as `const` and use reference types when returning data via parameter or when we need to actually modify the function input.

## Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
