### PR TITLE
Big grid sizes were collapsing

### DIFF
--- a/Content/__ExternalActors__/Levels/Battle/5/MZ/EDP3YOKRJ352TR68INY6TA.uasset
+++ b/Content/__ExternalActors__/Levels/Battle/5/MZ/EDP3YOKRJ352TR68INY6TA.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db9577f339fa4647edb9c045d53df28946655256f350a75607a99349f8ddd15c
-size 4322
+oid sha256:9bd6868e0dd302516ea033539361ffe86ff6cab831bfcafe54bcc2d07073c16a
+size 4414

--- a/Source/AmebamanBattleNetjob/BattleManager.cpp
+++ b/Source/AmebamanBattleNetjob/BattleManager.cpp
@@ -52,20 +52,18 @@ void ABattleManager::SpawnPlayerActor(UWorld *world){
 void ABattleManager::SpawnEnemyGrid(UWorld *world, const FTransform &transform){
 	// Move enemy grid according to Player Grid Size and Center
 	FVector PlayerGridSize = PlayerGrid->GetGridSize();
-	FVector PlayerGridCenter = PlayerGrid->GetGridCenter();
-	FVector PlayerGridOffset = {0, PlayerGridSize.Y+PlayerGridCenter.Y+GridOffset.Y, 0};
+	FVector PlayerGridReferenceSize = {0, PlayerGridSize.Y+OffsetBetweenGrids.Y, 0};
 
 	// Generate Enemy Grid
 	EnemyGrid = world->SpawnActor<AGrid>(EnemyGridBlueprint);
 	EnemyGrid->Offset = GridTilesOffset;
 	EnemyGrid->GenerateGrid(EnemyGridDimensions);
 	FVector EnemyGridSize = EnemyGrid->GetGridSize();
-	FVector EnemyGridCenter = EnemyGrid->GetGridCenter();
-	FVector TotalOffset = {0,PlayerGridOffset.Y+EnemyGridSize.Y,0};
+	FVector EnemyGridLocation = {0,PlayerGridReferenceSize.Y+EnemyGridSize.Y,0};
 	
 	// Update Transform
 	FTransform RelocateTransform = transform;
-	RelocateTransform.SetTranslation(TotalOffset);
+	RelocateTransform.SetTranslation(EnemyGridLocation);
 	EnemyGrid->SetActorTransform(RelocateTransform);
 }
 

--- a/Source/AmebamanBattleNetjob/BattleManager.cpp
+++ b/Source/AmebamanBattleNetjob/BattleManager.cpp
@@ -24,7 +24,7 @@ void ABattleManager::SetupBattle(){
 	};
 	const FTransform &enemyTransform = {
 		{0, 0, 0}, 
-		{0, 430, 0}, 
+		{0, 0, 0}, 
 		{1, 1, 1} 
 	};
 
@@ -34,7 +34,7 @@ void ABattleManager::SetupBattle(){
 
 void ABattleManager::SpawnPlayer(UWorld *world, const FTransform &transform){
 	PlayerGrid = world->SpawnActor<AGrid>(PlayerGridBlueprint, transform);
-	PlayerGrid->Offset = gridTilesOffset;
+	PlayerGrid->Offset = GridTilesOffset;
 	PlayerGrid->GenerateGrid(PlayerGridDimensions);
 
 	Player = world->SpawnActor<AGridPawn>(PlayerBlueprint);
@@ -46,9 +46,23 @@ void ABattleManager::SpawnPlayer(UWorld *world, const FTransform &transform){
 }
  
 void ABattleManager::SpawnEnemies(UWorld *world, const FTransform &transform){
-	EnemyGrid = world->SpawnActor<AGrid>(EnemyGridBlueprint, transform);
-	EnemyGrid->Offset = gridTilesOffset;
+	// Move enemy grid according to Player Grid Size and Center
+	FVector PlayerGridSize = PlayerGrid->GetGridSize();
+	FVector PlayerGridCenter = PlayerGrid->GetGridCenter();
+	FVector PlayerGridOffset = {0, PlayerGridSize.Y+PlayerGridCenter.Y+GridOffset.Y, 0};
+
+	// Generate Enemy Grid
+	EnemyGrid = world->SpawnActor<AGrid>(EnemyGridBlueprint);
+	EnemyGrid->Offset = GridTilesOffset;
 	EnemyGrid->GenerateGrid(EnemyGridDimensions);
+	FVector EnemyGridSize = EnemyGrid->GetGridSize();
+	FVector EnemyGridCenter = EnemyGrid->GetGridCenter();
+	FVector TotalOffset = {0,PlayerGridOffset.Y+EnemyGridSize.Y,0};
+	
+	// Update Transform
+	FTransform RelocateTransform = transform;
+	RelocateTransform.SetTranslation(TotalOffset);
+	EnemyGrid->SetActorTransform(RelocateTransform);
 
 	for(int i = 0; i < EnemyBlueprint.Num(); i++){
 		Enemies.Add(world->SpawnActor<AGridPawn>(EnemyBlueprint[i]));

--- a/Source/AmebamanBattleNetjob/BattleManager.cpp
+++ b/Source/AmebamanBattleNetjob/BattleManager.cpp
@@ -68,7 +68,7 @@ void ABattleManager::SpawnEnemyGrid(UWorld *world, const FTransform &transform){
 }
 
 void ABattleManager::SpawnEnemiesActors(UWorld *world){
-		for(int i = 0; i < EnemyBlueprint.Num(); i++){
+	for(int i = 0; i < EnemyBlueprint.Num(); i++){
 		Enemies.Add(world->SpawnActor<AGridPawn>(EnemyBlueprint[i]));
 		Enemies[i]->Setup(EnemyGrid, this);
 		EnemyGrid->PlacePawnInGrid(Enemies[i], EnemiesGridInitialLocation[i]);

--- a/Source/AmebamanBattleNetjob/BattleManager.cpp
+++ b/Source/AmebamanBattleNetjob/BattleManager.cpp
@@ -28,15 +28,19 @@ void ABattleManager::SetupBattle(){
 		{1, 1, 1} 
 	};
 
-	SpawnPlayer(world, playerTransform);
-	SpawnEnemies(world, enemyTransform);
+	SpawnPlayerGrid(world, playerTransform);
+	SpawnPlayerActor(world);
+	SpawnEnemyGrid(world, enemyTransform);
+	SpawnEnemiesActors(world);
 } 
 
-void ABattleManager::SpawnPlayer(UWorld *world, const FTransform &transform){
+void ABattleManager::SpawnPlayerGrid(UWorld *world, const FTransform &transform){
 	PlayerGrid = world->SpawnActor<AGrid>(PlayerGridBlueprint, transform);
 	PlayerGrid->Offset = GridTilesOffset;
 	PlayerGrid->GenerateGrid(PlayerGridDimensions);
+}
 
+void ABattleManager::SpawnPlayerActor(UWorld *world){
 	Player = world->SpawnActor<AGridPawn>(PlayerBlueprint);
 	Player->Setup(PlayerGrid, this);
 	PlayerGrid->PlacePawnInGrid(Player, PlayerGridInitialLocation);
@@ -45,7 +49,7 @@ void ABattleManager::SpawnPlayer(UWorld *world, const FTransform &transform){
 	controller->Possess(Player);
 }
  
-void ABattleManager::SpawnEnemies(UWorld *world, const FTransform &transform){
+void ABattleManager::SpawnEnemyGrid(UWorld *world, const FTransform &transform){
 	// Move enemy grid according to Player Grid Size and Center
 	FVector PlayerGridSize = PlayerGrid->GetGridSize();
 	FVector PlayerGridCenter = PlayerGrid->GetGridCenter();
@@ -63,8 +67,10 @@ void ABattleManager::SpawnEnemies(UWorld *world, const FTransform &transform){
 	FTransform RelocateTransform = transform;
 	RelocateTransform.SetTranslation(TotalOffset);
 	EnemyGrid->SetActorTransform(RelocateTransform);
+}
 
-	for(int i = 0; i < EnemyBlueprint.Num(); i++){
+void ABattleManager::SpawnEnemiesActors(UWorld *world){
+		for(int i = 0; i < EnemyBlueprint.Num(); i++){
 		Enemies.Add(world->SpawnActor<AGridPawn>(EnemyBlueprint[i]));
 		Enemies[i]->Setup(EnemyGrid, this);
 		EnemyGrid->PlacePawnInGrid(Enemies[i], EnemiesGridInitialLocation[i]);
@@ -74,7 +80,6 @@ void ABattleManager::SpawnEnemies(UWorld *world, const FTransform &transform){
 		// controller->Possess(enemy);
 	}
 }
-
 
 
 void ABattleManager::PlayerAttackCallback(FIntVector target_offset, int damage){

--- a/Source/AmebamanBattleNetjob/BattleManager.h
+++ b/Source/AmebamanBattleNetjob/BattleManager.h
@@ -72,6 +72,8 @@ protected:
 	TArray<TSubclassOf<AGridPawn>> EnemyBlueprint;
 
 private:
-	void SpawnPlayer(UWorld *world, const FTransform &transform);
-	void SpawnEnemies(UWorld *world, const FTransform &transform);
+	void SpawnPlayerGrid(UWorld *world, const FTransform &transform);
+	void SpawnEnemyGrid(UWorld *world, const FTransform &transform);
+	void SpawnPlayerActor(UWorld *world);
+	void SpawnEnemiesActors(UWorld *world);
 };

--- a/Source/AmebamanBattleNetjob/BattleManager.h
+++ b/Source/AmebamanBattleNetjob/BattleManager.h
@@ -40,7 +40,7 @@ protected:
 	UPROPERTY(EditAnywhere)
 	FVector GridTilesOffset = FVector{110, 110, 1100};
 	UPROPERTY(EditAnywhere)
-	FVector GridOffset = FVector{0,10,0};
+	FVector OffsetBetweenGrids = FVector{0,10,0};
 
 	// Player properties
 	UPROPERTY()

--- a/Source/AmebamanBattleNetjob/BattleManager.h
+++ b/Source/AmebamanBattleNetjob/BattleManager.h
@@ -38,8 +38,9 @@ protected:
 	void OnBattleLost();
 	
 	UPROPERTY(EditAnywhere)
-	FVector gridTilesOffset = FVector{110, 110, 1100};
-
+	FVector GridTilesOffset = FVector{110, 110, 1100};
+	UPROPERTY(EditAnywhere)
+	FVector GridOffset = FVector{0,10,0};
 
 	// Player properties
 	UPROPERTY()

--- a/Source/AmebamanBattleNetjob/Grid.cpp
+++ b/Source/AmebamanBattleNetjob/Grid.cpp
@@ -51,6 +51,12 @@ void AGrid::GenerateGrid(int width, int depth, int height) {
 		tileExtent.Z*Cells.Z
 	);
 
+	// To export the total grid size we need to add the size between each tile inside the grid
+	FVector tileNewOffset = Offset - TileBaseSize;
+	FVector gridOffsetSize = FVector(tileNewOffset.X*(Cells.X-1)/2.0, tileNewOffset.Y*(Cells.Y-1)/2.0, tileNewOffset.Z*(Cells.Z-1)/2.0);
+	GridSize = gridSize+gridOffsetSize;
+	GridCenter = tileCenter;
+
 	// we clean the temp actor
 	tempActor->Destroy();
 
@@ -220,4 +226,22 @@ int32 AGrid::RemovePawnFromGrid(AGridPawn *pawn){
 	}
 
 	return GridPawnMap.Num();
+}
+
+inline FVector AGrid::GetGridSize(){
+	return GridSize;
+}
+
+inline FVector AGrid::GetGridCenter(){
+	return GridCenter;
+}
+
+inline FVector AGrid::SetGridSize(FVector newSize){
+	GridSize = newSize;
+	return GridSize;
+}
+
+inline FVector AGrid::SetGridCenter(FVector newCenter){
+	GridCenter = newCenter;
+	return GridCenter;
 }

--- a/Source/AmebamanBattleNetjob/Grid.cpp
+++ b/Source/AmebamanBattleNetjob/Grid.cpp
@@ -52,8 +52,10 @@ void AGrid::GenerateGrid(int width, int depth, int height) {
 	);
 
 	// To export the total grid size we need to add the size between each tile inside the grid
-	FVector tileNewOffset = Offset - TileBaseSize;
-	FVector gridOffsetSize = FVector(tileNewOffset.X*(Cells.X-1)/2.0, tileNewOffset.Y*(Cells.Y-1)/2.0, tileNewOffset.Z*(Cells.Z-1)/2.0);
+	FVector offsetBetweenTiles = Offset - TileBaseSize;
+	FVector gridOffsetSize = FVector(offsetBetweenTiles.X*(Cells.X-1)/2.0,
+									 offsetBetweenTiles.Y*(Cells.Y-1)/2.0, 
+									 offsetBetweenTiles.Z*(Cells.Z-1)/2.0);
 	GridSize = gridSize+gridOffsetSize;
 	GridCenter = tileCenter;
 

--- a/Source/AmebamanBattleNetjob/Grid.h
+++ b/Source/AmebamanBattleNetjob/Grid.h
@@ -62,14 +62,28 @@ public:
 	bool GetPawnInfo(AGridPawn *pawn, FTileData& result);
 	bool GetPawnInfo(FIntVector gridLocation, FTileData& result);
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	FVector Offset;
+	UFUNCTION(BlueprintCallable)
+	FVector GetGridSize();
+	
+	UFUNCTION(BlueprintCallable)
+	FVector GetGridCenter();
 
+	UFUNCTION(BlueprintCallable)
+	FVector SetGridSize(FVector newSize);
+	
+	UFUNCTION(BlueprintCallable)
+	FVector SetGridCenter(FVector newCenter);
+	
 	// Conversions between [x, y, z] 3D array to [idx] 1D array of positions
 	inline int FIntVectorToGridArrayIndex(int x, int y, int z);
 	inline int FIntVectorToGridArrayIndex(FIntVector index3D);
 	inline FIntVector GridArrayIndexToFIntVector(int idx);
 	int32 RemovePawnFromGrid(AGridPawn *pawn);
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FVector Offset;
+
+	const FVector TileBaseSize = {100,100,10};
 
 protected:
 	// Called when the game starts or when spawned
@@ -91,4 +105,6 @@ protected:
 private:
 	TArray<FTileData> GridData;
 	TMap<FString, FTileData> GridPawnMap;
+	FVector GridSize;
+	FVector GridCenter;
 };


### PR DESCRIPTION
# Description
*Updating the grid location logic when spawning grids so that they would not collapse (e.g., enemy grid starting inside player grid) + Other general usability updates*

## Consequences
*Improved the grid logic generation and naming convention.*

## Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
